### PR TITLE
Support weekly offset queries

### DIFF
--- a/app/api/user_routes.py
+++ b/app/api/user_routes.py
@@ -6,7 +6,14 @@ from fastapi import APIRouter, HTTPException
 from app.schemas.user_schema import UserResponse, UserUpdate
 from app.schemas.ingredient_schema import IngredientResponse
 from app.schemas.user_ingredient_schema import UserIngredientCreate, UserIngredientResponse
-from app.services.user_service import get_user_details_by_id, get_weekly_completion, get_most_productive_day, get_meals_completion_summary_string, get_weekly_evolution_data, update_user_profile
+from app.services.user_service import (
+    get_user_details_by_id,
+    get_weekly_completion,
+    get_most_productive_day,
+    get_meals_completion_summary_string,
+    get_weekly_evolution_data,
+    update_user_profile,
+)
 from app.services.user_ingredient_service import create_user_ingredient_entry, get_user_ingredients, remove_user_ingredient_entry
 
 router = APIRouter()
@@ -19,20 +26,36 @@ def get_user(user_id: int, db: Session = Depends(get_session)):
     return user
 
 @router.get("/{user_id}/weekly/completion", response_model=int)
-def get_weekly_completion_endpoint(user_id: int, db: Session = Depends(get_session)):
-    return get_weekly_completion(user_id, db)
+def get_weekly_completion_endpoint(
+    user_id: int,
+    weekOffset: int = 0,
+    db: Session = Depends(get_session),
+):
+    return get_weekly_completion(user_id, db, weekOffset)
 
 @router.get("/{user_id}/weekly/top/days", response_model=str)
-def get_most_productive_day_endpoint(user_id: int, db: Session = Depends(get_session)):
-    return get_most_productive_day(db, user_id)
+def get_most_productive_day_endpoint(
+    user_id: int,
+    weekOffset: int = 0,
+    db: Session = Depends(get_session),
+):
+    return get_most_productive_day(db, user_id, weekOffset)
 
 @router.get("/{user_id}/meal/completion/summary", response_model=str)
-def get_meals_completion_summary(user_id: int, db: Session = Depends(get_session)):
-    return get_meals_completion_summary_string(db, user_id)
+def get_meals_completion_summary(
+    user_id: int,
+    weekOffset: int = 0,
+    db: Session = Depends(get_session),
+):
+    return get_meals_completion_summary_string(db, user_id, weekOffset)
 
 @router.get("/{user_id}/weekly/evolution", response_model=list[int])
-def get_weekly_evolution_per_day(user_id: int, db: Session = Depends(get_session)):
-    return get_weekly_evolution_data(db, user_id)
+def get_weekly_evolution_per_day(
+    user_id: int,
+    weekOffset: int = 0,
+    db: Session = Depends(get_session),
+):
+    return get_weekly_evolution_data(db, user_id, weekOffset)
 
 @router.put("/{user_id}/profile", response_model=UserResponse)
 def update_user(user_id: int, update_data: UserUpdate, db: Session = Depends(get_session)):

--- a/app/repositories/user_repository.py
+++ b/app/repositories/user_repository.py
@@ -71,18 +71,31 @@ def get_most_productive_days(db: Session, user_id: int, start_date: date, end_da
 
     return [int(row[0]) for row in result]
 
-def get_meals_completion_counts(db: Session, user_id: int) -> tuple[int, int]:
+def get_meals_completion_counts(
+    db: Session, user_id: int, start_date: date, end_date: date
+) -> tuple[int, int]:
+    """Return completed and total meals for a user in a date range."""
+
     total_comidas_cumplidas = (
         db.query(PlanFood)
         .join(Plan)
-        .filter(Plan.user_id == user_id, PlanFood.status == "Completado")
+        .filter(
+            Plan.user_id == user_id,
+            PlanFood.status == "Completado",
+            Plan.date >= start_date,
+            Plan.date <= end_date,
+        )
         .count()
     )
 
     total_comidas_registradas = (
         db.query(PlanFood)
         .join(Plan)
-        .filter(Plan.user_id == user_id)
+        .filter(
+            Plan.user_id == user_id,
+            Plan.date >= start_date,
+            Plan.date <= end_date,
+        )
         .count()
     )
 

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -2,7 +2,14 @@ from sqlalchemy.orm import Session
 from datetime import date, timedelta
 from typing import List
 from app.schemas.user_schema import UserResponse, UserUpdate
-from app.repositories.user_repository import get_user_by_id, get_weekly_completion_percentage, get_most_productive_days, get_meals_completion_counts, get_weekly_completed_per_day, save_user
+from app.repositories.user_repository import (
+    get_user_by_id,
+    get_weekly_completion_percentage,
+    get_most_productive_days,
+    get_meals_completion_counts,
+    get_weekly_completed_per_day,
+    save_user,
+)
 from fastapi import HTTPException
 
 def calculate_imc(height: float, weight: float) -> float | None:
@@ -20,19 +27,23 @@ def get_user_details_by_id(db: Session, user_id: int) -> UserResponse:
     
     return UserResponse.model_validate(user)
 
-def get_weekly_completion(user_id: int, db: Session) -> int:
-    today = date.today()
+def get_weekly_completion(user_id: int, db: Session, week_offset: int = 0) -> int:
+    """Return the completion percentage for the requested week."""
+
+    today = date.today() - timedelta(weeks=week_offset)
     start_of_week = today - timedelta(days=today.weekday())
     end_of_week = start_of_week + timedelta(days=6)
 
-    completed, total = get_weekly_completion_percentage(db, user_id, start_of_week, end_of_week)
+    completed, total = get_weekly_completion_percentage(
+        db, user_id, start_of_week, end_of_week
+    )
 
     if total == 0:
         return 0
     return int((completed / total) * 100)
 
-def get_most_productive_day(db: Session, user_id: int) -> str:
-    today = date.today()
+def get_most_productive_day(db: Session, user_id: int, week_offset: int = 0) -> str:
+    today = date.today() - timedelta(weeks=week_offset)
     start_of_week = today - timedelta(days=today.weekday())
     end_of_week = start_of_week + timedelta(days=6)
 
@@ -58,12 +69,20 @@ def get_most_productive_day(db: Session, user_id: int) -> str:
     else:
         return ", ".join(day_abbrs)
     
-def get_meals_completion_summary_string(db: Session, user_id: int) -> str:
-    completed, total = get_meals_completion_counts(db, user_id)
+def get_meals_completion_summary_string(
+    db: Session, user_id: int, week_offset: int = 0
+) -> str:
+    today = date.today() - timedelta(weeks=week_offset)
+    start_of_week = today - timedelta(days=today.weekday())
+    end_of_week = start_of_week + timedelta(days=6)
+
+    completed, total = get_meals_completion_counts(
+        db, user_id, start_of_week, end_of_week
+    )
     return f"{completed} / {total}"
 
-def get_weekly_evolution_data(db: Session, user_id: int) -> List[int]:
-    today = date.today()
+def get_weekly_evolution_data(db: Session, user_id: int, week_offset: int = 0) -> List[int]:
+    today = date.today() - timedelta(weeks=week_offset)
     monday = today - timedelta(days=today.weekday())
     sunday = monday + timedelta(days=6)
 


### PR DESCRIPTION
## Summary
- allow user progress endpoints to select past weeks
- compute week ranges in service layer
- update meal summary repository to work with date ranges

## Testing
- `python -m py_compile app/api/user_routes.py app/services/user_service.py app/repositories/user_repository.py`

------
https://chatgpt.com/codex/tasks/task_e_686f04d6792c8325ae9efd28d54366c3